### PR TITLE
feat: allow to override default ShoulderSurfingImpl.isAttacking with a new callback

### DIFF
--- a/api/src/main/java/com/github/exopandora/shouldersurfing/api/callback/IAttackStateCallback.java
+++ b/api/src/main/java/com/github/exopandora/shouldersurfing/api/callback/IAttackStateCallback.java
@@ -1,0 +1,53 @@
+package com.github.exopandora.shouldersurfing.api.callback;
+
+import com.github.exopandora.shouldersurfing.api.model.TurningMode;
+import net.minecraft.client.Minecraft;
+
+/**
+ * This callback allows implementing custom logic to determine whether the player is attacking.
+ * Useful for supporting custom attack keybinds that differ from the vanilla attack key.
+ * The final result is calculated from all partial results using a logical OR. If no callback provides a definitive result, the default attack logic is used.
+ */
+public interface IAttackStateCallback
+{
+	/**
+	 * Determines whether the player is currently attacking.
+	 *
+	 * @param context The arguments of this callback, containing the {@link Minecraft} instance and the {@link TurningMode} used when attacking.
+	 * @return The result of this callback:
+	 * <ul>
+	 *   <li>{@link Result#TRUE} – forces the attack state to <code>true</code></li>
+	 *   <li>{@link Result#FALSE} – forces the attack state to <code>false</code></li>
+	 *   <li>{@link Result#PASS} – ignores this callback and lets others or the default logic decide</li>
+	 * </ul>
+	 */
+	Result isAttacking(Context context);
+	
+	/**
+	 * The arguments passed to an {@link IAttackStateCallback}.
+	 *
+	 * @param minecraft          The Minecraft instance.
+	 * @param turningMode        The {@link TurningMode} used when attacking.
+	 * @param defaultIsAttacking The result of the default attack check,
+	 *                           equivalent to <code>minecraft.options.keyAttack.isDown()
+	 *                           && turningMode.shouldTurn(minecraft.hitResult)</code>.
+	 *                           This value is provided for reference when deciding whether to override
+	 *                           or pass in the callback.
+	 */
+	record Context(Minecraft minecraft, TurningMode turningMode, boolean defaultIsAttacking)
+	{
+	}
+	
+	/**
+	 * Represents the possible outcomes of an {@link IAttackStateCallback}.
+	 */
+	enum Result
+	{
+		/** Forces the attack state to <code>true</code>. */
+		TRUE,
+		/** Forces the attack state to <code>false</code>. */
+		FALSE,
+		/** Defers to other callbacks or the default logic. */
+		PASS
+	}
+}

--- a/api/src/main/java/com/github/exopandora/shouldersurfing/api/plugin/IShoulderSurfingRegistrar.java
+++ b/api/src/main/java/com/github/exopandora/shouldersurfing/api/plugin/IShoulderSurfingRegistrar.java
@@ -1,6 +1,7 @@
 package com.github.exopandora.shouldersurfing.api.plugin;
 
 import com.github.exopandora.shouldersurfing.api.callback.IAdaptiveItemCallback;
+import com.github.exopandora.shouldersurfing.api.callback.IAttackStateCallback;
 import com.github.exopandora.shouldersurfing.api.callback.ICameraCouplingCallback;
 import com.github.exopandora.shouldersurfing.api.callback.ICameraEntityTransparencyCallback;
 import com.github.exopandora.shouldersurfing.api.callback.ITargetCameraOffsetCallback;
@@ -22,4 +23,6 @@ public interface IShoulderSurfingRegistrar
 	IShoulderSurfingRegistrar registerTargetCameraOffsetCallback(ITargetCameraOffsetCallback targetCameraOffsetCallback);
 	
 	IShoulderSurfingRegistrar registerCameraEntityTransparencyCallback(ICameraEntityTransparencyCallback cameraEntityTransparencyCallback);
+	
+	IShoulderSurfingRegistrar registerAttackStateCallback(IAttackStateCallback callback);
 }

--- a/common/src/main/java/com/github/exopandora/shouldersurfing/plugin/ShoulderSurfingRegistrar.java
+++ b/common/src/main/java/com/github/exopandora/shouldersurfing/plugin/ShoulderSurfingRegistrar.java
@@ -1,6 +1,7 @@
 package com.github.exopandora.shouldersurfing.plugin;
 
 import com.github.exopandora.shouldersurfing.api.callback.IAdaptiveItemCallback;
+import com.github.exopandora.shouldersurfing.api.callback.IAttackStateCallback;
 import com.github.exopandora.shouldersurfing.api.callback.ICameraCouplingCallback;
 import com.github.exopandora.shouldersurfing.api.callback.ICameraEntityTransparencyCallback;
 import com.github.exopandora.shouldersurfing.api.callback.ITargetCameraOffsetCallback;
@@ -23,6 +24,7 @@ public class ShoulderSurfingRegistrar implements IShoulderSurfingRegistrar
 	private final List<ITargetCameraOffsetCallback> targetCameraOffsetCallbacks = new LinkedList<ITargetCameraOffsetCallback>();
 	private final List<ICameraEntityTransparencyCallback> cameraEntityTransparencyCallbacks = new LinkedList<ICameraEntityTransparencyCallback>();
 	private final List<ITickableCallback> tickableCallbacks = new LinkedList<ITickableCallback>();
+	private final List<IAttackStateCallback> attackStateCallbacks = new LinkedList<IAttackStateCallback>();
 	
 	private boolean isFrozen;
 	private PluginContext activePluginContext;
@@ -54,6 +56,12 @@ public class ShoulderSurfingRegistrar implements IShoulderSurfingRegistrar
 	public IShoulderSurfingRegistrar registerCameraEntityTransparencyCallback(ICameraEntityTransparencyCallback cameraEntityTransparencyCallback)
 	{
 		return this.registerCallback(this.cameraEntityTransparencyCallbacks, cameraEntityTransparencyCallback, ICameraEntityTransparencyCallback.class);
+	}
+	
+	@Override
+	public IShoulderSurfingRegistrar registerAttackStateCallback(IAttackStateCallback callback)
+	{
+		return this.registerCallback(this.attackStateCallbacks, callback, IAttackStateCallback.class);
 	}
 	
 	private <T> IShoulderSurfingRegistrar registerCallback(List<T> registry, T callback, Class<T> klass)
@@ -120,6 +128,11 @@ public class ShoulderSurfingRegistrar implements IShoulderSurfingRegistrar
 	public List<ITickableCallback> getTickableCallbacks()
 	{
 		return Collections.unmodifiableList(this.tickableCallbacks);
+	}
+	
+	public List<IAttackStateCallback> getAttackStateCallbacks()
+	{
+		return Collections.unmodifiableList(this.attackStateCallbacks);
 	}
 	
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Allows to override the default `ShoulderSurfingImpl.isAttacking` to support custom keybinds from other mods. Useful to solve https://github.com/Epic-Fight/epicfight/issues/2111.

There is also `ICameraCouplingCallback` (added in #295), which seems to be related, and could be used to solve the same problem, but this is a more specialized callback and provides `TurningMode` and `defaultIsAttacking`.

### Related Issues

- *Fix #345*
- *Related https://github.com/Epic-Fight/epicfight/issues/2111*