### PR TITLE
Add Third-party Integrations to Compatibility section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,16 @@ The binaries for each platform can be found in the following directories:
 
 </details>
 
+<details>
+  <summary>Third-party integrations*</summary>
+
+These are community-made mods that add optional support for this mod. They are **not officially supported** and may not be compatible with all versions.
+
+- [Shoulder Surfing: Iron's Spells Integration](https://modrinth.com/mod/shoulder-surfing-iron-spells-integration)
+- [Shoulder Surfing - Pehkui Compat](https://modrinth.com/mod/shoulder-surfing-pehkui-compat)
+
+</details>
+
 \* Mods are listed A-Z.
 
 # License #


### PR DESCRIPTION
There are other integrations such as [Shoulder Surfing - Pehkui Compat](https://modrinth.com/mod/shoulder-surfing-pehkui-compat), might be useful to list them somewhere in the mod's README on Modrinth and Curse Forge so users can discover them.

As for Iron's Spells Integration, when installed, it should fix the issue in #328 and other issues as well.