### PR TITLE
Handle Epic Fight Camera breaking changes

### DIFF
--- a/common/src/main/java/com/github/exopandora/shouldersurfing/compat/Mods.java
+++ b/common/src/main/java/com/github/exopandora/shouldersurfing/compat/Mods.java
@@ -50,7 +50,7 @@ public enum Mods
 		return this.getModVersion() != null;
 	}
 	
-	private static boolean existsClass(String className)
+	public static boolean existsClass(String className)
 	{
 		try
 		{

--- a/common/src/main/java/com/github/exopandora/shouldersurfing/compat/ShoulderSurfingCompatMixinPlugin.java
+++ b/common/src/main/java/com/github/exopandora/shouldersurfing/compat/ShoulderSurfingCompatMixinPlugin.java
@@ -1,5 +1,6 @@
 package com.github.exopandora.shouldersurfing.compat;
 
+import com.github.exopandora.shouldersurfing.ShoulderSurfingCommon;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 
 import java.util.List;
@@ -61,8 +62,16 @@ public abstract class ShoulderSurfingCompatMixinPlugin implements IMixinConfigPl
 	{
 		if(Mods.EPIC_FIGHT.isLoaded())
 		{
-			mixins.add("epicfight.AccessorCamera");
-			mixins.add("epicfight.MixinRenderEngine");
+			final boolean supportsNewerCameraApi = Mods.existsClass("yesman.epicfight.api.client.camera.EpicFightCameraAPI");
+			if(supportsNewerCameraApi)
+			{
+				ShoulderSurfingCommon.LOGGER.debug("Epic Fight integration has been disabled due to the recent updates and breakage.");
+			}
+			else
+			{
+				mixins.add("epicfight.AccessorCamera");
+				mixins.add("epicfight.MixinRenderEngine");
+			}
 		}
 	}
 	


### PR DESCRIPTION
Workarounds https://github.com/Exopandora/ShoulderSurfing/issues/359#issuecomment-3551814165.

Epic Fight has removed the methods that the Shoulder Surfing mixin onto support lock-on.
It's more future-proof if Epic Fight provides explicit support for lock-on.

I already sent a PR to Epic Fight to [add deprecated methods](https://github.com/Epic-Fight/epicfight/pull/2224/files#diff-857904bf46a6db49080264e24ef789f2793bf3e204fa85859e73dc65ddf1d944R375-R391) to avoid crashes, but these methods will be removed in future updates.

This may not sound like an ideal solution, but it's temporary, and Epic Fight integration can be fully removed from the Shoulder Surfing side so Epic Fight can add explicit lock-on support in future updates. 

The Epic Fight version can contain 4 parts, and the first major part is tied to the Minecraft version (`21`, `20`).

Epic Fight may adapt [Semantic Versioning 2.0.0](https://semver.org/) after 1.22, but for now, parsing the version could be error-prone.