### PR TITLE
[1.21.1] Handle Epic Fight Camera breaking changes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,1 +1,2 @@
 - Fix compatibility with Cobblemon 1.7+
+- Disable outdated Epic Fight mixins for versions `21.14.0`, and newer to prevent future crashes

--- a/common/src/main/java/com/github/exopandora/shouldersurfing/compat/ShoulderSurfingCompatMixinPlugin.java
+++ b/common/src/main/java/com/github/exopandora/shouldersurfing/compat/ShoulderSurfingCompatMixinPlugin.java
@@ -1,5 +1,6 @@
 package com.github.exopandora.shouldersurfing.compat;
 
+import com.github.exopandora.shouldersurfing.ShoulderSurfingCommon;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 
 import java.util.List;
@@ -58,12 +59,41 @@ public abstract class ShoulderSurfingCompatMixinPlugin implements IMixinConfigPl
 		}
 	}
 	
+	private static boolean shouldApplyEpicFightMixins()
+	{
+		final String version = Mods.EPIC_FIGHT.getModVersion();
+		if(version == null)
+		{
+			return false;
+		}
+		try
+		{
+			final String[] parts = version.split("\\.");
+			final int major = Integer.parseInt(parts[0]);
+			final int minor = Integer.parseInt(parts[1]);
+			
+			return major == 21 && minor < 14;
+		}
+		catch(Exception e)
+		{
+			ShoulderSurfingCommon.LOGGER.error("Failed to parse the Epic Fight mod version '{}': {}", version, e.toString());
+			return false;
+		}
+	}
+	
 	private static void addEpicFightMixins(List<String> mixins)
 	{
 		if(Mods.EPIC_FIGHT.isLoaded())
 		{
-			mixins.add("epicfight.AccessorCamera");
-			mixins.add("epicfight.MixinRenderEngine");
+			if(shouldApplyEpicFightMixins())
+			{
+				mixins.add("epicfight.AccessorCamera");
+				mixins.add("epicfight.MixinRenderEngine");
+			}
+			else
+			{
+				ShoulderSurfingCommon.LOGGER.info("Epic Fight lock-on support provided by Shoulder Surfing has been disabled due to breaking changes in '21.14.0'. For more details: https://github.com/Epic-Fight/epicfight/issues/2258");
+			}
 		}
 	}
 	


### PR DESCRIPTION
Workarounds https://github.com/Exopandora/ShoulderSurfing/issues/359#issuecomment-3551814165.

Epic Fight has removed the methods that the Shoulder Surfing mixin onto support lock-on.
It's more future-proof if Epic Fight provides explicit support for lock-on (https://github.com/Epic-Fight/epicfight/issues/2258).

I have sent a PR to Epic Fight to [add deprecated methods](https://github.com/Epic-Fight/epicfight/pull/2224/files#diff-857904bf46a6db49080264e24ef789f2793bf3e204fa85859e73dc65ddf1d944R375-R391) to avoid crashes, but these methods will be removed in future updates.

This may not sound like an ideal solution, but it's temporary, and Epic Fight integration can be fully removed from the Shoulder Surfing side, so Epic Fight can add explicit lock-on support in future updates. 

The Epic Fight version can contain 4 parts, and the first major part is tied to the Minecraft minor version (`21`, `20`).

Epic Fight may adapt [Semantic Versioning 2.0.0](https://semver.org/) after 1.22, but for now, parsing the full version could be error-prone.