### PR TITLE
[1.8.9] Fix a fatal bug in an early Minecraft version

### DIFF
--- a/src/main/java/com/teamderpy/shouldersurfing/client/ShoulderHelper.java
+++ b/src/main/java/com/teamderpy/shouldersurfing/client/ShoulderHelper.java
@@ -261,7 +261,7 @@ public class ShoulderHelper
 			
 			if(item != null)
 			{
-				Item current = stack.getItem();
+				Item current = item.getItem();
 				
 				if(current instanceof ItemBow)
 				{


### PR DESCRIPTION
While playing on multiplayer servers, consuming a golden apple during combat could occasionally trigger a NullPointerException and crash the game. This appears to happen in cases when item state updates occur during use and the item stack changes unexpectedly.