### PR TITLE
Valkyrien Skies 2 compat for 1.20.1

### DIFF
--- a/buildSrc/src/main/kotlin/multiloader-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/multiloader-common.gradle.kts
@@ -69,6 +69,12 @@ repositories {
             includeGroup("maven.modrinth")
         }
     }
+    maven("https://maven.valkyrienskies.org") {
+        content {
+            includeGroup("org.valkyrienskies")
+            includeGroup("org.valkyrienskies.core")
+        }
+    }
 }
 
 tasks.withType<Jar>().configureEach {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -13,12 +13,14 @@ base {
 dependencies {
 	compileOnly(project(":api"))
 	compileOnly(project(":compat"))
-	
+
 	compileOnly(libs.mixin)
 	compileOnly(libs.forgeconfigapiport.common)
 	compileOnly(libs.wthit.common)
 	compileOnly(libs.jade.common)
 	compileOnly(libs.cobblemon.common)
+    api(libs.valkyrienskies.common) { isTransitive = false }
+    compileOnly(libs.vscoreapi)
 }
 
 minecraft {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -19,8 +19,8 @@ dependencies {
 	compileOnly(libs.wthit.common)
 	compileOnly(libs.jade.common)
 	compileOnly(libs.cobblemon.common)
-    api(libs.valkyrienskies.common) { isTransitive = false }
     compileOnly(libs.vscoreapi)
+    compileOnly(libs.valkyrienskies.common) { isTransitive = false }
 }
 
 minecraft {

--- a/common/src/main/java/com/github/exopandora/shouldersurfing/client/ObjectPicker.java
+++ b/common/src/main/java/com/github/exopandora/shouldersurfing/client/ObjectPicker.java
@@ -40,6 +40,7 @@ public class ObjectPicker implements IObjectPicker
 			
 			if(distance < interactionRange || blockHit.getType() != HitResult.Type.MISS)
 			{
+				
 				return entityHit;
 			}
 		}
@@ -62,9 +63,6 @@ public class ObjectPicker implements IObjectPicker
 	@Override
 	public BlockHitResult pickBlocks(PickContext context, double interactionRange, float partialTick)
 	{
-		if (Mods.VALKYRIEN_SKIES.isLoaded()) {
-			return RaycastUtilsKt.clipIncludeShips(context.entity().level(), context.toClipContext(interactionRange, partialTick), false);
-		}
-		return  context.entity().level().clip(context.toClipContext(interactionRange, partialTick));
+		return context.entity().level().clip(context.toClipContext(interactionRange, partialTick));
 	}
 }

--- a/common/src/main/java/com/github/exopandora/shouldersurfing/client/ObjectPicker.java
+++ b/common/src/main/java/com/github/exopandora/shouldersurfing/client/ObjectPicker.java
@@ -3,6 +3,7 @@ package com.github.exopandora.shouldersurfing.client;
 import com.github.exopandora.shouldersurfing.api.client.IObjectPicker;
 import com.github.exopandora.shouldersurfing.api.model.Couple;
 import com.github.exopandora.shouldersurfing.api.model.PickContext;
+import com.github.exopandora.shouldersurfing.compat.Mods;
 import net.minecraft.client.multiplayer.MultiPlayerGameMode;
 import net.minecraft.world.entity.projectile.ProjectileUtil;
 import net.minecraft.world.phys.AABB;
@@ -10,6 +11,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
+import org.valkyrienskies.mod.common.world.RaycastUtilsKt;
 
 public class ObjectPicker implements IObjectPicker
 {
@@ -60,6 +62,9 @@ public class ObjectPicker implements IObjectPicker
 	@Override
 	public BlockHitResult pickBlocks(PickContext context, double interactionRange, float partialTick)
 	{
-		return context.entity().level().clip(context.toClipContext(interactionRange, partialTick));
+		if (Mods.VALKYRIEN_SKIES.isLoaded()) {
+			return RaycastUtilsKt.clipIncludeShips(context.entity().level(), context.toClipContext(interactionRange, partialTick), false);
+		}
+		return  context.entity().level().clip(context.toClipContext(interactionRange, partialTick));
 	}
 }

--- a/common/src/main/java/com/github/exopandora/shouldersurfing/compat/Mods.java
+++ b/common/src/main/java/com/github/exopandora/shouldersurfing/compat/Mods.java
@@ -20,6 +20,7 @@ public enum Mods
 	SKIN_LAYERS,
 	THE_ONE_PROBE,
 	TSLAT_ENTITY_STATUS,
+	VALKYRIEN_SKIES,
 	WILDFIRE_GENDER;
 	
 	private static final Map<Mods, @Nullable String> MODS_TO_VERSION = new HashMap<Mods, String>();

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -33,8 +33,8 @@ dependencies {
 	modImplementation(libs.badpackets.fabric)
 	modImplementation(libs.jade.fabric)
 	modCompileOnly(libs.cobblemon.fabric)
-    modApi(libs.valkyrienskies.fabric) { isTransitive = false }
     modCompileOnly(libs.vscoreapi)
+    modCompileOnly(libs.valkyrienskies.fabric) { isTransitive = false }
 }
 
 loom {

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
 	modImplementation(libs.badpackets.fabric)
 	modImplementation(libs.jade.fabric)
 	modCompileOnly(libs.cobblemon.fabric)
+    modApi(libs.valkyrienskies.fabric) { isTransitive = false }
+    modCompileOnly(libs.vscoreapi)
 }
 
 loom {
@@ -91,12 +93,12 @@ publishMods {
 	curseforge {
 		minecraftVersions.set(compatibleVersions)
 		requires("fabric-api", "forge-config-api-port")
-		incompatible("better-third-person", "nimble-fabric", "valkyrien-skies")
+		incompatible("better-third-person", "nimble-fabric")
 	}
 	
 	modrinth {
 		minecraftVersions.set(compatibleVersions)
 		requires("fabric-api", "forge-config-api-port")
-		incompatible("better-third-person", "nimble", "valkyrien-skies")
+		incompatible("better-third-person", "nimble")
 	}
 }

--- a/fabric/src/main/java/com/github/exopandora/shouldersurfing/fabric/Platform.java
+++ b/fabric/src/main/java/com/github/exopandora/shouldersurfing/fabric/Platform.java
@@ -22,7 +22,7 @@ public class Platform implements IPlatform
 			case SKIN_LAYERS -> findModVersionForId("skinlayers3d");
 			case THE_ONE_PROBE -> findModVersionForId("theoneprobe");
 			case TSLAT_ENTITY_STATUS -> findModVersionForId("tslatentitystatus");
-			case VALKYRIEN_SKIES -> findModVersionForId("valkyrien-skies");
+			case VALKYRIEN_SKIES -> findModVersionForId("valkyrienskies");
 			case WILDFIRE_GENDER -> findModVersionForId("wildfire_gender");
 		};
 	}

--- a/fabric/src/main/java/com/github/exopandora/shouldersurfing/fabric/Platform.java
+++ b/fabric/src/main/java/com/github/exopandora/shouldersurfing/fabric/Platform.java
@@ -22,6 +22,7 @@ public class Platform implements IPlatform
 			case SKIN_LAYERS -> findModVersionForId("skinlayers3d");
 			case THE_ONE_PROBE -> findModVersionForId("theoneprobe");
 			case TSLAT_ENTITY_STATUS -> findModVersionForId("tslatentitystatus");
+			case VALKYRIEN_SKIES -> findModVersionForId("valkyrien-skies");
 			case WILDFIRE_GENDER -> findModVersionForId("wildfire_gender");
 		};
 	}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -40,8 +40,7 @@
 	"breaks": {
 		"betterthirdperson": "*",
 		"camerautils": "*",
-		"nimble": "*",
-		"valkyrienskies": "*"
+		"nimble": "*"
 	},
 	"conflicts": {
 		"theoneprobe": "*"

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -63,8 +63,8 @@ dependencies {
 	implementation(fg.deobf(libs.jade.forge.get()))
 	compileOnly(fg.deobf(libs.curios.forge.get()))
     compileOnly(fg.deobf(libs.cobblemon.forge.get()))
-    api(fg.deobf(libs.valkyrienskies.forge.get()))
     compileOnly(libs.vscoreapi)
+    compileOnly(fg.deobf(libs.valkyrienskies.forge.get()))
 }
 
 tasks.named<ProcessResources>("processResources") {

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -63,6 +63,8 @@ dependencies {
 	implementation(fg.deobf(libs.jade.forge.get()))
 	compileOnly(fg.deobf(libs.curios.forge.get()))
     compileOnly(fg.deobf(libs.cobblemon.forge.get()))
+    api(fg.deobf(libs.valkyrienskies.forge.get()))
+    compileOnly(libs.vscoreapi)
 }
 
 tasks.named<ProcessResources>("processResources") {
@@ -107,12 +109,12 @@ publishMods {
 	
 	curseforge {
 		minecraftVersions.set(compatibleVersions)
-		incompatible("better-third-person", "nimble", "valkyrien-skies", "ydms-custom-camera-view")
+		incompatible("better-third-person", "nimble", "ydms-custom-camera-view")
 	}
 	
 	modrinth {
 		minecraftVersions.set(compatibleVersions)
-		incompatible("better-third-person", "nimble", "valkyrien-skies", "ydms-custom-camera-view")
+		incompatible("better-third-person", "nimble", "ydms-custom-camera-view")
 	}
 }
 

--- a/forge/src/main/java/com/github/exopandora/shouldersurfing/forge/Platform.java
+++ b/forge/src/main/java/com/github/exopandora/shouldersurfing/forge/Platform.java
@@ -25,6 +25,7 @@ public class Platform implements IPlatform
 			case SKIN_LAYERS -> findModVersionForId("skinlayers3d");
 			case THE_ONE_PROBE -> findModVersionForId("theoneprobe");
 			case TSLAT_ENTITY_STATUS -> findModVersionForId("tslatentitystatus");
+			case VALKYRIEN_SKIES -> findModVersionForId("valkyrien-skies");
 			case WILDFIRE_GENDER -> findModVersionForId("wildfire_gender");
 		};
 	}

--- a/forge/src/main/java/com/github/exopandora/shouldersurfing/forge/Platform.java
+++ b/forge/src/main/java/com/github/exopandora/shouldersurfing/forge/Platform.java
@@ -25,7 +25,7 @@ public class Platform implements IPlatform
 			case SKIN_LAYERS -> findModVersionForId("skinlayers3d");
 			case THE_ONE_PROBE -> findModVersionForId("theoneprobe");
 			case TSLAT_ENTITY_STATUS -> findModVersionForId("tslatentitystatus");
-			case VALKYRIEN_SKIES -> findModVersionForId("valkyrien-skies");
+			case VALKYRIEN_SKIES -> findModVersionForId("valkyrienskies");
 			case WILDFIRE_GENDER -> findModVersionForId("wildfire_gender");
 		};
 	}

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -13,7 +13,7 @@ logoFile = "logo.png"
 displayURL = "${modUrl}"
 
 [modproperties.${modId}]
-incompatibleMods = ["betterthirdperson", "customcameraview", "nimble", "valkyrienskies"]
+incompatibleMods = ["betterthirdperson", "customcameraview", "nimble"]
 
 [[dependencies.${modId}]]
 modId = "minecraft"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,9 @@ curios = "5.14.1+1.20.1"
 cobblemon-common = "vm5zUZAg" # forge-1.5.2+1.20.1
 cobblemon-forge = "vm5zUZAg" # forge-1.5.2+1.20.1
 cobblemon-fabric = "EVozVxCq" # fabric-1.5.2+1.20.1
+valkyrien-120-forge = "1.20.1-forge-2.4.11"
+valkyrien-120-fabric = "1.20.1-fabric-2.4.11"
+valkyrien-core = "1.1.0+cf208d8b56"
 
 [libraries]
 minecraft-forge = { module = "net.minecraftforge:forge", version.ref = "forge" }
@@ -38,6 +41,10 @@ curios-forge = { module = "top.theillusivec4.curios:curios-forge", version.ref =
 cobblemon-common = { module = "maven.modrinth:cobblemon", version.ref = "cobblemon-common" }
 cobblemon-forge = { module = "maven.modrinth:cobblemon", version.ref = "cobblemon-forge" }
 cobblemon-fabric = { module = "maven.modrinth:cobblemon", version.ref = "cobblemon-fabric" }
+valkyrienskies-common = {module = "maven.modrinth:valkyrien-skies", version.ref = "valkyrien-120-forge"}
+valkyrienskies-forge = {module = "maven.modrinth:valkyrien-skies", version.ref = "valkyrien-120-forge"}
+valkyrienskies-fabric = {module = "maven.modrinth:valkyrien-skies", version.ref = "valkyrien-120-fabric"}
+vscoreapi = {module = "org.valkyrienskies.core:api", version.ref = "valkyrien-core"}
 
 [plugins]
 modpublishplugin = { id = "me.modmuss50.mod-publish-plugin", version = "0.6.3" }


### PR DESCRIPTION
This PR removes the incompatibility notation for VS2 and adds compatibility.
If VS2 is loaded, pickBlocks method of Shoulder surfing will use Valkyrien Skies Raycast utility to get the clip result that is on shipyard(virtual space that VS ship blocks are actually on).
This might not be clean solution, due to it bypassing the level().clip() and might be having side effects; please consider this as a ducktape PR.
Ideally it would be better to have a custom clip context in VS side to see if the raycast result should be transformed, so I'll make another PR after such change is updated to VS.